### PR TITLE
center product cards (#3)

### DIFF
--- a/client/css/home-page.css
+++ b/client/css/home-page.css
@@ -39,4 +39,5 @@ main
 	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 	gap: 0.5em;
 	padding: 2em 0 5em 0;
+	align-items: center;
 }


### PR DESCRIPTION
Closes #3 

![](https://user-images.githubusercontent.com/61280281/103140350-93834c80-470b-11eb-82d0-581766d176a5.png)

I realized instead of using flexbox, I could get the same results with grid by simply adding a line: `align-items: center;`

![image](https://user-images.githubusercontent.com/61280281/103472669-f3d25800-4db5-11eb-8a32-d1ee72bcccc4.png)


